### PR TITLE
Fix bugs in retention strategy

### DIFF
--- a/src/main/java/com/microsoft/jenkins/containeragents/strategy/ContainerIdleRetentionStrategy.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/strategy/ContainerIdleRetentionStrategy.java
@@ -9,19 +9,66 @@ package com.microsoft.jenkins.containeragents.strategy;
 
 import hudson.Extension;
 import hudson.model.Descriptor;
+import hudson.slaves.AbstractCloudComputer;
+import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.RetentionStrategy;
+import hudson.util.TimeUnit2;
+import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.concurrent.GuardedBy;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static hudson.util.TimeUnit2.MINUTES;
+import static java.util.logging.Level.WARNING;
+
 public class ContainerIdleRetentionStrategy extends CloudRetentionStrategy {
+    private static final Logger LOGGER = Logger.getLogger(ContainerIdleRetentionStrategy.class.getName());
+
     private int idleMinutes = 0;
+    private static final transient int LAPSE = 5;
 
     @DataBoundConstructor
     public ContainerIdleRetentionStrategy(int idleMinutes) {
         super(idleMinutes);
         this.idleMinutes = idleMinutes;
+    }
+
+    @Override
+    @GuardedBy("hudson.model.Queue.lock")
+    public long check(final AbstractCloudComputer c) {
+        final AbstractCloudSlave computerNode = c.getNode();
+        if (c.isIdle() && !disabled && computerNode != null) {
+            final long milliBetweenCreationAndIdle = c.getIdleStartMilliseconds() - c.getConnectTime();
+            boolean neverConnected = milliBetweenCreationAndIdle < TimeUnit2.SECONDS.toMillis(LAPSE);
+
+            // neverConnected will always be true after jenkins restart so that slave will not be deleted
+            // So overwrite neverConnected if slave exists after restart
+            if (c.getIdleStartMilliseconds() - Jenkins.getInstance().toComputer().getConnectTime()
+                    < TimeUnit2.SECONDS.toMillis(LAPSE)) {
+                neverConnected = false;
+            }
+
+            final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
+            if (idleMinutes != 0
+                    && !neverConnected
+                    && idleMilliseconds > MINUTES.toMillis(idleMinutes)) {
+                LOGGER.log(Level.INFO, "Disconnecting {0}", c.getName());
+                try {
+                    computerNode.terminate();
+                } catch (InterruptedException e) {
+                    LOGGER.log(WARNING, "Failed to terminate " + c.getName(), e);
+                } catch (IOException e) {
+                    LOGGER.log(WARNING, "Failed to terminate " + c.getName(), e);
+                }
+            }
+        }
+        return 1;
     }
 
     public int getIdleMinutes() {

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-retentionStrategy.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-retentionStrategy.html
@@ -3,5 +3,5 @@
     For each job in the queue, an own docker container is started. Once the job has finished, the container is shut down.<br/><br/>
     <b>Container Idle Retention Strategy</b><br/>
     Based on the workload provided by the queue (load average), new docker containers are started on demand. After the job(s) have finished, the container is not shut down immediately. <br/>
-    If no new job was executed on this slave/container during the period of the Idle delay, the container is shut down.
+    If no new job was executed on this slave/container during the period of the Idle delay, the container is shut down. Retention time 0 means never being deleted automatically.
 </dev>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-retentionStrategy.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-retentionStrategy.html
@@ -3,5 +3,5 @@
     For each job in the queue, an own docker container is started. Once the job has finished, the container is shut down.<br/><br/>
     <b>Container Idle Retention Strategy</b><br/>
     Based on the workload provided by the queue (load average), new docker containers are started on demand. After the job(s) have finished, the container is not shut down immediately. <br/>
-    If no new job was executed on this slave/container during the period of the Idle delay, the container is shut down.
+    If no new job was executed on this slave/container during the period of the Idle delay, the container is shut down. Retention time 0 means never being deleted automatically.
 </dev>


### PR DESCRIPTION
Fix two bugs in origin retention strategy:
* Idle retention strategy will delete slave before provision finished if idle time is not large enough
* Once retention strategy will not delete unused slave after Jenkins restart