### PR TITLE
Fix CNFE when running with newer windows-azure-storage plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,16 +43,16 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <azuresdk.version>1.19.0</azuresdk.version>
         <jackson.version>2.9.8</jackson.version>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.89.4</jenkins.version>
         <java.level>8</java.level>
         <findbugs.failOnError>true</findbugs.failOnError>
         <findbugs.excludeFilterFile>findbugs-exclude.xml</findbugs.excludeFilterFile>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <azure-credentials.version>1.6.1</azure-credentials.version>
         <kubernetes-client.version>2.3.1</kubernetes-client.version>
-        <azure-commons.version>1.0.3</azure-commons.version>
+        <azure-commons.version>1.0.4</azure-commons.version>
         <docker-commons.version>1.3.1</docker-commons.version>
-        <windows-azure-storage.version>0.3.6</windows-azure-storage.version>
+        <windows-azure-storage.version>1.1.1</windows-azure-storage.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/microsoft/jenkins/containeragents/aci/AciComputer.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/aci/AciComputer.java
@@ -9,6 +9,6 @@ public class AciComputer extends AbstractCloudComputer<AciAgent> {
 
     @Override
     public String toString() {
-        return String.format("AciComputer name: %s slave: %s", getName(), getNode());
+        return String.format("AciComputer name: %s agent: %s", getName(), getNode());
     }
 }

--- a/src/main/java/com/microsoft/jenkins/containeragents/aci/volumes/AzureFileVolume.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/aci/volumes/AzureFileVolume.java
@@ -3,7 +3,7 @@ package com.microsoft.jenkins.containeragents.aci.volumes;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-import com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials;
+import com.microsoftopentechnologies.windowsazurestorage.helper.AzureStorageAccount;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -23,7 +23,7 @@ public class AzureFileVolume extends AbstractDescribableImpl<AzureFileVolume> im
     private final String mountPath;
     private final String shareName;
     private final String credentialsId;
-    private final AzureCredentials.StorageAccountCredential credentials;
+    private final AzureStorageAccount.StorageAccountCredential credentials;
 
     @DataBoundConstructor
     public AzureFileVolume(final String mountPath,
@@ -32,7 +32,7 @@ public class AzureFileVolume extends AbstractDescribableImpl<AzureFileVolume> im
         this.mountPath = mountPath;
         this.shareName = shareName;
         this.credentialsId = credentialsId;
-        this.credentials = AzureCredentials.getStorageAccountCredential(credentialsId);
+        this.credentials = AzureStorageAccount.getStorageAccountCredential(credentialsId);
     }
 
     public String getMountPath() {
@@ -65,7 +65,7 @@ public class AzureFileVolume extends AbstractDescribableImpl<AzureFileVolume> im
 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item owner) {
             StandardListBoxModel model = new StandardListBoxModel();
-            model.withAll(CredentialsProvider.lookupCredentials(AzureCredentials.class,
+            model.withAll(CredentialsProvider.lookupCredentials(AzureStorageAccount.class,
                     owner,
                     ACL.SYSTEM,
                     Collections.<DomainRequirement>emptyList()));


### PR DESCRIPTION
Currently, if running with a newer version of windows-azure-storage plugin, a ClassNotFoundException will occur for the StorageCredentials because the interface was moved/renamed. This fixes that issue. This can cause problems loading the config from storage and thus loses the configuration for the templates.

Also, update slave -> agent.