### PR TITLE
Update to correct image names and terminology for user facing messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Although Kubernetes supports multi-containers in a Pod, but we only support one 
 Please ensure JenkinsURL, secret and nodeName passed to container via arguments or environment variables.
 
 1. Specify `Name` and `Labels`
-2. Choose a `Docker image`. Please note that the slave will connect with master via JNLP, so make sure JNLP installed in image. Default image is `jenkins/jnlp-slave` and you can also use it as base image.
+2. Choose a `Docker image`. Please note that the agent will connect with master via JNLP, so make sure JNLP installed in image. Default image is `jenkins/inbound-agent` and you can also use it as base image.
 3. If you use a private registry, you need to specify a credential and you have two choices:
     * Use a Private Registry Secret. You need to [create a Secret](https://kubernetes.io/docs/concepts/configuration/secret/) in your Kubernetes cluster in advance and then fill in the Secret name.
     * Use a Private Registry Credential. You just need to fill in the credential and we will create a Secret for you.
@@ -137,7 +137,7 @@ Jenkins.getInstance().clouds.add(myCloud)
 1. Specify `Name` and `Labels`
 2. Set `Startup Timeout`.
 3. Select `Image OS Type`, Windows or Linux.
-4. Fill in `Docker Image`. Please note that the slave will connect with master via JNLP, so make sure JNLP installed in image. Default image is `jenkins/jnlp-slave` and you can also use it as base image.
+4. Fill in `Docker Image`. Please note that the agent will connect with master via JNLP, so make sure JNLP installed in image. Default image is `jenkins/inbound-agent` and you can also use it as base image.
 5. If you use a private registry, you need to specify a credential.
 6. Specify a `Command`. Now the `Command` will override the ENTRYPOINT. `Arguments`. `${rootUrl}`, `${secret}` and `${nodeName}` will be replace with JenkinsUrl, Secret and ComputerNodeName automatically.
 7. Specify the `Working Dir`. You must ensure login user have the write permission to this directory.

--- a/src/main/java/com/microsoft/jenkins/containeragents/KubernetesCloud.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/KubernetesCloud.java
@@ -192,7 +192,7 @@ public class KubernetesCloud extends Cloud {
 
                 return slave;
             } catch (Exception ex) {
-                LOGGER.log(Level.WARNING, "Error in provisioning; slave={0}, template={1}: {2}",
+                LOGGER.log(Level.WARNING, "Error in provisioning; agent={0}, template={1}: {2}",
                         new Object[] {slave, template, ex});
 
                 properties.put("Message", ex.getMessage());
@@ -203,7 +203,7 @@ public class KubernetesCloud extends Cloud {
                     try {
                         slave.terminate();
                     } catch (IOException e) {
-                        LOGGER.log(Level.WARNING, "Error in cleaning up the slave node " + slave.getNodeName(), e);
+                        LOGGER.log(Level.WARNING, "Error in cleaning up the agent node " + slave.getNodeName(), e);
                     }
                 }
                 provisionRetryStrategy.failure(template.getName());
@@ -282,7 +282,7 @@ public class KubernetesCloud extends Cloud {
     }
 
     public void deletePod(String podName) {
-        LOGGER.log(Level.INFO, "Terminating container instance for slave {0}", podName);
+        LOGGER.log(Level.INFO, "Terminating container instance for agent {0}", podName);
         final Map<String, String> properties = new HashMap<>();
 
         try (KubernetesClient client = connect()) {
@@ -293,12 +293,12 @@ public class KubernetesCloud extends Cloud {
             ContainerPlugin.sendEvent(Constants.AI_CONTAINER_AGENT, "Deleted", properties);
 
             if (result) {
-                LOGGER.log(Level.INFO, "Terminated Kubernetes instance for slave {0}", podName);
+                LOGGER.log(Level.INFO, "Terminated Kubernetes instance for agent {0}", podName);
             } else {
-                LOGGER.log(Level.WARNING, "Failed to terminate pod for slave " + podName);
+                LOGGER.log(Level.WARNING, "Failed to terminate pod for agent " + podName);
             }
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to terminate pod for slave " + podName, e);
+            LOGGER.log(Level.WARNING, "Failed to terminate pod for agent " + podName, e);
 
             properties.put("Message", e.getMessage());
             ContainerPlugin.sendEvent(Constants.AI_CONTAINER_AGENT, "DeletedFailed", properties);

--- a/src/main/java/com/microsoft/jenkins/containeragents/builders/AciContainerTemplateFluent.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/builders/AciContainerTemplateFluent.java
@@ -53,8 +53,8 @@ public class AciContainerTemplateFluent<T extends AciContainerTemplateFluent<T>>
     AciContainerTemplateFluent() {
         timeout = 10;
         osType = "Linux";
-        image = "jenkinsci/jnlp-slave";
-        command = "jenkins-slave -url ${rootUrl} ${secret} ${nodeName}";
+        image = "jenkins/inbound-agent";
+        command = "jenkins-agent -url ${rootUrl} ${secret} ${nodeName}";
         rootFs = "/home/jenkins";
         retentionStrategy = new ContainerOnceRetentionStrategy();
         cpu = "1";

--- a/src/main/java/com/microsoft/jenkins/containeragents/builders/PodTemplateFluent.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/builders/PodTemplateFluent.java
@@ -64,7 +64,7 @@ public class PodTemplateFluent<T extends PodTemplateFluent<T>> {
     private String sshPort;
 
     public PodTemplateFluent() {
-        this.image = "jenkinsci/jnlp-slave";
+        this.image = "jenkins/inbound-agent";
         this.args = "-url ${rootUrl} ${secret} ${nodeName}";
         this.rootFs = "/jenkins";
         this.retentionStrategy = new ContainerOnceRetentionStrategy();

--- a/src/main/java/com/microsoft/jenkins/containeragents/remote/SSHLauncher.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/remote/SSHLauncher.java
@@ -70,12 +70,12 @@ public class SSHLauncher extends ComputerLauncher {
                 }
             }, new SSHRetryStrategy(RETRY_LIMIT, RETRY_INTERVAL)).call();
 
-            InputStream inputStream = new ByteArrayInputStream(Jenkins.getInstance().getJnlpJars("slave.jar")
+            InputStream inputStream = new ByteArrayInputStream(Jenkins.getInstance().getJnlpJars("agent.jar")
                     .readFully());
-            sshClient.copyTo(inputStream, "slave.jar");
-            LOGGER.log(Level.INFO, "SSHLauncher: Copy slave.jar to remote host successfully");
+            sshClient.copyTo(inputStream, "agent.jar");
+            LOGGER.log(Level.INFO, "SSHLauncher: Copy agent.jar to remote host successfully");
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "SSHLauncher: Copy slave.jar to remote host failed");
+            LOGGER.log(Level.WARNING, "SSHLauncher: Copy agent.jar to remote host failed");
             computer.setAcceptingTasks(false);
             throw new InterruptedException(e.toString());
         }
@@ -96,7 +96,7 @@ public class SSHLauncher extends ComputerLauncher {
             }, new SSHRetryStrategy(RETRY_LIMIT, RETRY_INTERVAL)).call();
 
             final ChannelExec channelExec = (ChannelExec) session.openChannel("exec");
-            final String execCommand = "java -jar slave.jar";
+            final String execCommand = "java -jar agent.jar";
             channelExec.setCommand(execCommand);
             channelExec.connect();
 

--- a/src/main/resources/com/microsoft/jenkins/containeragents/KubernetesCloud/config.properties
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/KubernetesCloud/config.properties
@@ -9,4 +9,4 @@ Testing=Testing...
 Startup_Timeout=Startup Timeout
 
 Images=Image
-Image_Description=List of Images to be launched as slaves
+Image_Description=List of Images to be launched as agents

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/config.jelly
@@ -11,7 +11,7 @@
     </f:entry>
 
     <f:entry field="image" title="${%Docker_Image}">
-        <f:textbox clazz="required" default="jenkinsci/jnlp-slave"/>
+        <f:textbox clazz="required" default="jenkins/inbound-agent"/>
     </f:entry>
 
     <f:entry title="${%Private_Registry_Secrets}">

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-args.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-args.html
@@ -1,6 +1,6 @@
 <div>
     Arguments to pass to the command.<br/>
     ${rootUrl}, ${secret} and ${nodeName} will be replace with JenkinsUrl, Secret and ComputerNodeName automatically.<br/>
-    <code>-url ${rootUrl} ${secret} ${nodeName}</code> for jenkinsci/jnlp-slave <br/>
-    Leave it blank for jenkinsci/ssh-slave
+    <code>-url ${rootUrl} ${secret} ${nodeName}</code> for jenkins/inbound-image <br/>
+    Leave it blank for jenkins/ssh-agent
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-image.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-image.html
@@ -1,4 +1,4 @@
 <div>
-    Docker image ID for a jenkins JNLP/SSH slave. This image is responsible to run a jenkins JNLP/SSH bootstrap agent and connect to Jenkins master.<br/>
-    You can use jenkinsci/jnlp-slave for JNLP or jenkinsci/ssh-slave for SSH or take their dockerfile as a reference
+    Docker image ID for a jenkins inbound/SSH agent. This image is responsible to run a jenkins inbound/SSH bootstrap agent and connect to Jenkins master.<br/>
+    You can use jenkins/inbound-agent for JNLP or jenkins/ssh-agent for SSH or take their dockerfile as a reference
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-launchMethodTypeContent.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-launchMethodTypeContent.html
@@ -1,18 +1,18 @@
 <div>
-    Choose JNLP or SSH to launch your slave.<br/><br/>
+    Choose JNLP or SSH to launch your agent.<br/><br/>
 
     JNLP<br/>
-    Make sure container can access Jenkins master. Take image jenkinsci/jnlp-slave as a reference<br/><br/>
+    Make sure container can access Jenkins master. Take image jenkins/inbound-agent as a reference<br/><br/>
 
     SSH<br/>
     Make sure container initialize with a SSH server and Jenkins can access to container<br/>
     You should install Jenkins master in the same ACS cluster.<br/>
-    Take image jenkinsci/ssh-slave as a reference<br/><br/>
+    Take image jenkins/ssh-agent as a reference<br/><br/>
 
     If using SSH, here is a sample of arguments:<br/>
-    &ensp;Docker image: jenkinsci/ssh-slave<br/>
+    &ensp;Docker image: jenkins/ssh-agent<br/>
     &ensp;Command: <br/>
     &ensp;Arguments: <br/>
-    &ensp;Environment Variable: Key: JENKINS_SLAVE_SSH_PUBKEY, Value: Your public key<br/>
+    &ensp;Environment Variable: Key: JENKINS_AGENT_SSH_PUBKEY, Value: Your public key<br/>
     &ensp;Launch Method: SSH
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-limitCpu.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-limitCpu.html
@@ -1,3 +1,3 @@
 <div>
-    Kubernetes Resources Limit of CPU This value can be set to control the CPU resource limit passed when creating the jenkins slave docker container in Kubernetes. Unlike a resource request, this is the upper limit of resources used by your Jenkins Slave container.
+    Kubernetes Resources Limit of CPU This value can be set to control the CPU resource limit passed when creating the jenkins agent docker container in Kubernetes. Unlike a resource request, this is the upper limit of resources used by your Jenkins Agent container.
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-limitMemory.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-limitMemory.html
@@ -1,3 +1,3 @@
 <div>
-    Kubernetes Resources Limit of Memory This value can be set to control the memory resource limit passed when creating the jenkins slave docker container in Kubernetes. Unlike a resource request, this is the upper limit of resources used by your Jenkins Slave container.
+    Kubernetes Resources Limit of Memory This value can be set to control the memory resource limit passed when creating the jenkins agent docker container in Kubernetes. Unlike a resource request, this is the upper limit of resources used by your Jenkins Agent container.
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-requestCpu.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-requestCpu.html
@@ -1,3 +1,3 @@
 <div>
-    Kubernetes Resources Request of CPU This value can be set to control the CPU resources requested when creating the jenkins slave docker container in Kubernetes.
+    Kubernetes Resources Request of CPU This value can be set to control the CPU resources requested when creating the jenkins agent docker container in Kubernetes.
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-requestMemory.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-requestMemory.html
@@ -1,3 +1,3 @@
 <div>
-    Kubernetes Resources Request of Memory This value can be set to control the memory resources requested when creating the jenkins slave docker container in Kubernetes.
+    Kubernetes Resources Request of Memory This value can be set to control the memory resources requested when creating the jenkins agent docker container in Kubernetes.
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-retentionStrategy.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-retentionStrategy.html
@@ -3,5 +3,5 @@
     For each job in the queue, an own docker container is started. Once the job has finished, the container is shut down.<br/><br/>
     <b>Container Idle Retention Strategy</b><br/>
     Based on the workload provided by the queue (load average), new docker containers are started on demand. After the job(s) have finished, the container is not shut down immediately. <br/>
-    If no new job was executed on this slave/container during the period of the Idle delay, the container is shut down. Retention time 0 means never being deleted automatically.
+    If no new job was executed on this agent/container during the period of the Idle delay, the container is shut down. Retention time 0 means never being deleted automatically.
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciCloud/config.properties
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciCloud/config.properties
@@ -2,4 +2,4 @@ Cloud_Name=Cloud Name
 Azure_Credential=Azure Credential
 Resource_Group=Resource Group
 Images=Image
-Image_Description=List of Images to be launched as slaves
+Image_Description=List of Images to be launched as agents

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/config.jelly
@@ -19,7 +19,7 @@
     </f:entry>
 
     <f:entry field="image" title="${%Docker_Image}">
-        <f:textbox clazz="required" default="jenkinsci/jnlp-slave"/>
+        <f:textbox clazz="required" default="jenkins/inbound-agent"/>
     </f:entry>
 
     <f:entry title="${%Private_Registry_Credentials}">
@@ -28,7 +28,7 @@
     </f:entry>
 
     <f:entry field="command" title="${%Command}">
-        <f:textbox default="jenkins-slave -url $${rootUrl} $${secret} $${nodeName}"/>
+        <f:textbox default="jenkins-agent -url $${rootUrl} $${secret} $${nodeName}"/>
     </f:entry>
 
     <f:entry field="rootFs" title="${%Working_Dir}">

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-command.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-command.html
@@ -1,6 +1,6 @@
 <div>
     The command line to run when the container is started. Command will override ENTRYPOINT now.<br/>
     ${rootUrl}, ${secret} and ${nodeName} will be replace with JenkinsUrl, Secret and ComputerNodeName automatically.<br/>
-    <code>jenkins-slave -url ${rootUrl} ${secret} ${nodeName}</code> for jenkinsci/jnlp-slave <br/>
-    <code>setup-sshd</code> for jenkinsci/ssh-slave
+    <code>jenkins-agent -url ${rootUrl} ${secret} ${nodeName}</code> for jenkins/inbound-agent <br/>
+    <code>setup-sshd</code> for jenkins/ssh-agent
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-image.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-image.html
@@ -1,4 +1,4 @@
 <div>
-    Docker image ID for a jenkins JNLP/SSH slave. This image is responsible to run a jenkins JNLP/SSH bootstrap agent and connect to Jenkins master.<br/>
-    You can use jenkinsci/jnlp-slave for JNLP or jenkinsci/ssh-slave for SSH or take theirs dockerfile as a reference
+    Docker image ID for a jenkins inbound/SSH agent. This image is responsible to run a jenkins inbound/SSH bootstrap agent and connect to Jenkins master.<br/>
+    You can use jenkins/inbound-agent for JNLP or jenkins/ssh-agent for SSH or take theirs dockerfile as a reference
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-launchMethodTypeContent.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-launchMethodTypeContent.html
@@ -1,15 +1,15 @@
 <div>
-    Choose JNLP or SSH to launch your slave.<br/><br/>
+    Choose JNLP or SSH to launch your agent.<br/><br/>
 
     JNLP<br/>
-    Make sure container can access Jenkins master. Take image jenkinsci/jnlp-slave as a reference<br/><br/>
+    Make sure container can access Jenkins master. Take image jenkins/inbound-agent as a reference<br/><br/>
 
     SSH<br/>
-    Make sure container initialize with a SSH server. Take image jenkinsci/ssh-slave as a reference<br/><br/>
+    Make sure container initialize with a SSH server. Take image jenkins/ssh-agent as a reference<br/><br/>
 
     If using SSH, here is a sample of arguments:<br/>
-    &ensp;Docker image: jenkinsci/ssh-slave<br/>
+    &ensp;Docker image: jenkins/ssh-agent<br/>
     &ensp;Command: setup-sshd<br/>
-    &ensp;Environment Variable: Key: JENKINS_SLAVE_SSH_PUBKEY, Value: Your public key<br/>
+    &ensp;Environment Variable: Key: JENKINS_AGENT_SSH_PUBKEY, Value: Your public key<br/>
     &ensp;Launch Method: SSH
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-retentionStrategy.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-retentionStrategy.html
@@ -3,5 +3,5 @@
     For each job in the queue, an own docker container is started. Once the job has finished, the container is shut down.<br/><br/>
     <b>Container Idle Retention Strategy</b><br/>
     Based on the workload provided by the queue (load average), new docker containers are started on demand. After the job(s) have finished, the container is not shut down immediately. <br/>
-    If no new job was executed on this slave/container during the period of the Idle delay, the container is shut down. Retention time 0 means never being deleted automatically.
+    If no new job was executed on this agent/container during the period of the Idle delay, the container is shut down. Retention time 0 means never being deleted automatically.
 </div>


### PR DESCRIPTION
- slave -> agent
- jenkinsci/jnlp-slave -> jenkins/inbound-agent
- jenkinsci/ssh-slave -> jenkins/ssh-agent
- some instance of jnlp -> inbound