### PR TITLE
Hacktoberfest - Rename docker images jnlp-slave and ssh-slave to inbound-agent and ssh-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Although Kubernetes supports multi-containers in a Pod, but we only support one 
 Please ensure JenkinsURL, secret and nodeName passed to container via arguments or environment variables.
 
 1. Specify `Name` and `Labels`
-2. Choose a `Docker image`. Please note that the slave will connect with master via JNLP, so make sure JNLP installed in image. Default image is `jenkins/jnlp-slave` and you can also use it as base image.
+2. Choose a `Docker image`. Please note that the slave will connect with master via JNLP, so make sure JNLP installed in image. Default image is `jenkins/inbound-agent` and you can also use it as base image.
 3. If you use a private registry, you need to specify a credential and you have two choices:
     * Use a Private Registry Secret. You need to [create a Secret](https://kubernetes.io/docs/concepts/configuration/secret/) in your Kubernetes cluster in advance and then fill in the Secret name.
     * Use a Private Registry Credential. You just need to fill in the credential and we will create a Secret for you.
@@ -137,7 +137,7 @@ Jenkins.getInstance().clouds.add(myCloud)
 1. Specify `Name` and `Labels`
 2. Set `Startup Timeout`.
 3. Select `Image OS Type`, Windows or Linux.
-4. Fill in `Docker Image`. Please note that the slave will connect with master via JNLP, so make sure JNLP installed in image. Default image is `jenkins/jnlp-slave` and you can also use it as base image.
+4. Fill in `Docker Image`. Please note that the slave will connect with master via JNLP, so make sure JNLP installed in image. Default image is `jenkins/inbound-agent` and you can also use it as base image.
 5. If you use a private registry, you need to specify a credential.
 6. Specify a `Command`. Now the `Command` will override the ENTRYPOINT. `Arguments`. `${rootUrl}`, `${secret}` and `${nodeName}` will be replace with JenkinsUrl, Secret and ComputerNodeName automatically.
 7. Specify the `Working Dir`. You must ensure login user have the write permission to this directory.

--- a/src/main/java/com/microsoft/jenkins/containeragents/builders/AciContainerTemplateFluent.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/builders/AciContainerTemplateFluent.java
@@ -53,7 +53,7 @@ public class AciContainerTemplateFluent<T extends AciContainerTemplateFluent<T>>
     AciContainerTemplateFluent() {
         timeout = 10;
         osType = "Linux";
-        image = "jenkinsci/jnlp-slave";
+        image = "jenkins/inbound-agent";
         command = "jenkins-slave -url ${rootUrl} ${secret} ${nodeName}";
         rootFs = "/home/jenkins";
         retentionStrategy = new ContainerOnceRetentionStrategy();

--- a/src/main/java/com/microsoft/jenkins/containeragents/builders/PodTemplateFluent.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/builders/PodTemplateFluent.java
@@ -64,7 +64,7 @@ public class PodTemplateFluent<T extends PodTemplateFluent<T>> {
     private String sshPort;
 
     public PodTemplateFluent() {
-        this.image = "jenkinsci/jnlp-slave";
+        this.image = "jenkins/inbound-agent";
         this.args = "-url ${rootUrl} ${secret} ${nodeName}";
         this.rootFs = "/jenkins";
         this.retentionStrategy = new ContainerOnceRetentionStrategy();

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/config.jelly
@@ -11,7 +11,7 @@
     </f:entry>
 
     <f:entry field="image" title="${%Docker_Image}">
-        <f:textbox clazz="required" default="jenkinsci/jnlp-slave"/>
+        <f:textbox clazz="required" default="jenkins/inbound-agent"/>
     </f:entry>
 
     <f:entry title="${%Private_Registry_Secrets}">

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-args.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-args.html
@@ -1,6 +1,6 @@
 <div>
     Arguments to pass to the command.<br/>
     ${rootUrl}, ${secret} and ${nodeName} will be replace with JenkinsUrl, Secret and ComputerNodeName automatically.<br/>
-    <code>-url ${rootUrl} ${secret} ${nodeName}</code> for jenkinsci/jnlp-slave <br/>
+    <code>-url ${rootUrl} ${secret} ${nodeName}</code> for jenkins/inbound-agent <br/>
     Leave it blank for jenkinsci/ssh-slave
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-args.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-args.html
@@ -2,5 +2,5 @@
     Arguments to pass to the command.<br/>
     ${rootUrl}, ${secret} and ${nodeName} will be replace with JenkinsUrl, Secret and ComputerNodeName automatically.<br/>
     <code>-url ${rootUrl} ${secret} ${nodeName}</code> for jenkins/inbound-agent <br/>
-    Leave it blank for jenkinsci/ssh-slave
+    Leave it blank for jenkins/ssh-agent
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-image.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-image.html
@@ -1,4 +1,4 @@
 <div>
     Docker image ID for a jenkins JNLP/SSH slave. This image is responsible to run a jenkins JNLP/SSH bootstrap agent and connect to Jenkins master.<br/>
-    You can use jenkinsci/jnlp-slave for JNLP or jenkinsci/ssh-slave for SSH or take their dockerfile as a reference
+    You can use jenkins/inbound-agent for JNLP or jenkinsci/ssh-slave for SSH or take their dockerfile as a reference
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-image.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-image.html
@@ -1,4 +1,4 @@
 <div>
     Docker image ID for a jenkins JNLP/SSH slave. This image is responsible to run a jenkins JNLP/SSH bootstrap agent and connect to Jenkins master.<br/>
-    You can use jenkins/inbound-agent for JNLP or jenkinsci/ssh-slave for SSH or take their dockerfile as a reference
+    You can use jenkins/inbound-agent for JNLP or jenkins/ssh-agent for SSH or take their dockerfile as a reference
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-launchMethodTypeContent.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-launchMethodTypeContent.html
@@ -2,7 +2,7 @@
     Choose JNLP or SSH to launch your slave.<br/><br/>
 
     JNLP<br/>
-    Make sure container can access Jenkins master. Take image jenkinsci/jnlp-slave as a reference<br/><br/>
+    Make sure container can access Jenkins master. Take image jenkins/inbound-agent as a reference<br/><br/>
 
     SSH<br/>
     Make sure container initialize with a SSH server and Jenkins can access to container<br/>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-launchMethodTypeContent.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/PodTemplate/help-launchMethodTypeContent.html
@@ -7,10 +7,10 @@
     SSH<br/>
     Make sure container initialize with a SSH server and Jenkins can access to container<br/>
     You should install Jenkins master in the same ACS cluster.<br/>
-    Take image jenkinsci/ssh-slave as a reference<br/><br/>
+    Take image jenkins/ssh-agent as a reference<br/><br/>
 
     If using SSH, here is a sample of arguments:<br/>
-    &ensp;Docker image: jenkinsci/ssh-slave<br/>
+    &ensp;Docker image: jenkins/ssh-agent<br/>
     &ensp;Command: <br/>
     &ensp;Arguments: <br/>
     &ensp;Environment Variable: Key: JENKINS_SLAVE_SSH_PUBKEY, Value: Your public key<br/>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/config.jelly
@@ -19,7 +19,7 @@
     </f:entry>
 
     <f:entry field="image" title="${%Docker_Image}">
-        <f:textbox clazz="required" default="jenkinsci/jnlp-slave"/>
+        <f:textbox clazz="required" default="jenkins/inbound-agent"/>
     </f:entry>
 
     <f:entry title="${%Private_Registry_Credentials}">

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-command.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-command.html
@@ -1,6 +1,6 @@
 <div>
     The command line to run when the container is started. Command will override ENTRYPOINT now.<br/>
     ${rootUrl}, ${secret} and ${nodeName} will be replace with JenkinsUrl, Secret and ComputerNodeName automatically.<br/>
-    <code>jenkins-slave -url ${rootUrl} ${secret} ${nodeName}</code> for jenkinsci/jnlp-slave <br/>
+    <code>jenkins-slave -url ${rootUrl} ${secret} ${nodeName}</code> for jenkins/inbound-agent <br/>
     <code>setup-sshd</code> for jenkinsci/ssh-slave
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-command.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-command.html
@@ -2,5 +2,5 @@
     The command line to run when the container is started. Command will override ENTRYPOINT now.<br/>
     ${rootUrl}, ${secret} and ${nodeName} will be replace with JenkinsUrl, Secret and ComputerNodeName automatically.<br/>
     <code>jenkins-slave -url ${rootUrl} ${secret} ${nodeName}</code> for jenkins/inbound-agent <br/>
-    <code>setup-sshd</code> for jenkinsci/ssh-slave
+    <code>setup-sshd</code> for jenkins/ssh-agent
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-image.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-image.html
@@ -1,4 +1,4 @@
 <div>
     Docker image ID for a jenkins JNLP/SSH slave. This image is responsible to run a jenkins JNLP/SSH bootstrap agent and connect to Jenkins master.<br/>
-    You can use jenkinsci/jnlp-slave for JNLP or jenkinsci/ssh-slave for SSH or take theirs dockerfile as a reference
+    You can use jenkins/inbound-agent for JNLP or jenkinsci/ssh-slave for SSH or take theirs dockerfile as a reference
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-image.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-image.html
@@ -1,4 +1,4 @@
 <div>
     Docker image ID for a jenkins JNLP/SSH slave. This image is responsible to run a jenkins JNLP/SSH bootstrap agent and connect to Jenkins master.<br/>
-    You can use jenkins/inbound-agent for JNLP or jenkinsci/ssh-slave for SSH or take theirs dockerfile as a reference
+    You can use jenkins/inbound-agent for JNLP or jenkins/ssh-agent for SSH or take theirs dockerfile as a reference
 </div>

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-launchMethodTypeContent.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-launchMethodTypeContent.html
@@ -5,10 +5,10 @@
     Make sure container can access Jenkins master. Take image jenkins/inbound-agent as a reference<br/><br/>
 
     SSH<br/>
-    Make sure container initialize with a SSH server. Take image jenkinsci/ssh-slave as a reference<br/><br/>
+    Make sure container initialize with a SSH server. Take image jenkins/ssh-agent as a reference<br/><br/>
 
     If using SSH, here is a sample of arguments:<br/>
-    &ensp;Docker image: jenkinsci/ssh-slave<br/>
+    &ensp;Docker image: jenkins/ssh-agent<br/>
     &ensp;Command: setup-sshd<br/>
     &ensp;Environment Variable: Key: JENKINS_SLAVE_SSH_PUBKEY, Value: Your public key<br/>
     &ensp;Launch Method: SSH

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-launchMethodTypeContent.html
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/help-launchMethodTypeContent.html
@@ -2,7 +2,7 @@
     Choose JNLP or SSH to launch your slave.<br/><br/>
 
     JNLP<br/>
-    Make sure container can access Jenkins master. Take image jenkinsci/jnlp-slave as a reference<br/><br/>
+    Make sure container can access Jenkins master. Take image jenkins/inbound-agent as a reference<br/><br/>
 
     SSH<br/>
     Make sure container initialize with a SSH server. Take image jenkinsci/ssh-slave as a reference<br/><br/>


### PR DESCRIPTION
As mentioned in https://www.jenkins.io/blog/2020/05/06/docker-agent-image-renaming/ and https://issues.jenkins-ci.org/browse/JENKINS-42846