### PR TITLE
Integrate Aci agents with cloud statistics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
             <version>30.1-jre</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloud-stats</artifactId>
+            <version>0.26</version>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>

--- a/src/main/java/com/microsoft/jenkins/containeragents/aci/AciComputer.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/aci/AciComputer.java
@@ -1,14 +1,25 @@
 package com.microsoft.jenkins.containeragents.aci;
 
 import hudson.slaves.AbstractCloudComputer;
+import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
+import org.jenkinsci.plugins.cloudstats.TrackedItem;
 
-public class AciComputer extends AbstractCloudComputer<AciAgent> {
+public class AciComputer extends AbstractCloudComputer<AciAgent> implements TrackedItem {
+
+    private final ProvisioningActivity.Id provisioningId;
+
     public AciComputer(AciAgent agent) {
         super(agent);
+        this.provisioningId = agent.getId();
     }
 
     @Override
     public String toString() {
         return String.format("AciComputer name: %s agent: %s", getName(), getNode());
+    }
+
+    @Override
+    public ProvisioningActivity.Id getId() {
+        return provisioningId;
     }
 }

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/config.jelly
@@ -11,7 +11,7 @@
     </f:entry>
 
     <f:entry field="timeout" title="${%Timeout}">
-        <f:textbox default="10"/>
+        <f:number default="10"/>
     </f:entry>
 
     <f:entry field="osType" title="${%Image_OsType}">

--- a/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/config.properties
+++ b/src/main/resources/com/microsoft/jenkins/containeragents/aci/AciContainerTemplate/config.properties
@@ -1,6 +1,6 @@
 Name=Name
 Labels=Labels
-Timeout=Startup Timeout
+Timeout=Startup Timeout (minutes)
 Image_OsType=Image OS Type
 Docker_Image=Docker Image
 Command=Command


### PR DESCRIPTION
Review with [whitespace disabled](https://github.com/jenkinsci/azure-container-agents-plugin/pull/68/files?w=1)

This adds at least some observability into what the plugin is doing for Aci agents, I couldn't get as much as I wanted due to limitations in the current API version but it's a lot better than before and is a real issue we have on ci.jenkins.io (not knowing what's going on when the agents aren't provisioning)...

![image](https://user-images.githubusercontent.com/21194782/112053117-db1f4600-8b4b-11eb-897b-5e1c31e3a10f.png)

Fixes https://github.com/jenkinsci/azure-container-agents-plugin/issues/28
