### PR TITLE
Use ContainerInstanceLogs for diagnostics.

### DIFF
--- a/src/main/java/com/microsoft/jenkins/containeragents/aci/AciService.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/aci/AciService.java
@@ -200,7 +200,7 @@ public final class AciService {
         ObjectNode diagnosticsNode = mapper.createObjectNode();
         ObjectNode logAnalyticsNode = mapper.createObjectNode();
         logAnalyticsNode.put("workspaceId", credentials.getUsername());
-        logAnalyticsNode.put("logType", "ContainerInsights");
+        logAnalyticsNode.put("logType", "ContainerInstanceLogs");
         logAnalyticsNode.put("workspaceKey", "[parameters('workspaceKey')]");
         diagnosticsNode.set("logAnalytics", logAnalyticsNode);
         ((ObjectNode) tmp.get("resources").get(0).get("properties"))


### PR DESCRIPTION
Use ContainerInstanceLogs for diagnostics.

ACI has 2 diagnostics types:
ContainerInsights: Push metrics only to LA
ContainerInstanceLogs: Push metrics and logs to LA

There is a bug in ACI where ContainerInsights push both metrics and logs to LA, ACI will be fixing this soon.

Pushing plugin logs to LA is the expected behavior. So I'm switching to ContainerInstanceLogs type, so when ACI fixes the bug on it's end, customers will still have the logs pushed to LA.
