### PR TITLE
If using Private IP Address and resource group of vnet is empty, the resource group is not used from the Azure Container Instance Configuration

### DIFF
--- a/src/main/java/com/microsoft/jenkins/containeragents/builders/AciDeploymentTemplateBuilder.java
+++ b/src/main/java/com/microsoft/jenkins/containeragents/builders/AciDeploymentTemplateBuilder.java
@@ -68,6 +68,7 @@ public final class AciDeploymentTemplateBuilder {
             variables.put("ipType", mapIpType(privateIpAddress));
             if (privateIpAddress != null) {
                 variables.put("vnetResourceGroupName", privateIpAddress.getResourceGroup() != null
+                        && !privateIpAddress.getResourceGroup().isEmpty()
                         ? privateIpAddress.getResourceGroup() : cloud.getResourceGroup());
                 variables.put("vnetName", privateIpAddress.getVnet());
                 variables.put("subnetName", privateIpAddress.getSubnet());

--- a/src/test/java/com/microsoft/jenkins/containeragents/builders/AciDeploymentTemplateBuilderTest.java
+++ b/src/test/java/com/microsoft/jenkins/containeragents/builders/AciDeploymentTemplateBuilderTest.java
@@ -69,6 +69,23 @@ public class AciDeploymentTemplateBuilderTest {
     }
 
     @Test
+    public void templateWithVnetAndOwnButEmptyRg() throws IOException {
+        AciCloud cloud = new AciCloud("testcloud", "credentialId", "resourceGroup", emptyList());
+
+        AciContainerTemplate template = new AciContainerTemplate("containerName", "label", 100, "linux", "helloworld", "command", "rootFs", emptyList(), emptyList(), emptyList(), emptyList(), new RetentionStrategy.Always(), "cpu", "memory" );
+        AciPrivateIpAddress privateIpAddress = new AciPrivateIpAddress("vnet", "subnet");
+        privateIpAddress.setResourceGroup("");
+        template.setPrivateIpAddress(privateIpAddress);
+
+        AciDeploymentTemplateBuilder.AciDeploymentTemplate aciDeploymentTemplate = builderUnderTest.buildDeploymentTemplate(cloud, template, agentMock);
+
+        assertThat(aciDeploymentTemplate.deploymentTemplateAsString(), containsString("\"vnetResourceGroupName\":\"resourceGroup\","));
+        assertThat(aciDeploymentTemplate.deploymentTemplateAsString(), containsString("\"vnetName\":\"vnet\","));
+        assertThat(aciDeploymentTemplate.deploymentTemplateAsString(), containsString("\"subnetName\":\"subnet\""));
+        assertThat(aciDeploymentTemplate.deploymentTemplateAsString(), containsString("\"subnetIds\":"));
+    }
+
+    @Test
     public void templateWithoutVnet() throws IOException {
         AciCloud cloud = new AciCloud("testcloud", "credentialId", "resourceGroup", emptyList());
 


### PR DESCRIPTION
Fixing empty resource group for vnet.

Closes #118 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
