### PR TITLE
Use `instance-identity` from BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,6 @@
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>142.v04572ca_5b_265</version>
         </dependency>
 
         <!-- test dependencies -->
@@ -121,7 +120,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.361.x</artifactId>
-                <version>1766.v0b_f2a_f7d0b_1d</version>
+                <version>1775.vf0577a_a_01778</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
No need for an explicit version now that this dependency is in the managed set.