### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/src/test/java/com/microsoft/jenkins/containeragents/AciCloudConfigTest.java
+++ b/src/test/java/com/microsoft/jenkins/containeragents/AciCloudConfigTest.java
@@ -9,21 +9,19 @@ import com.microsoft.jenkins.containeragents.aci.dns.AciDnsConfig;
 import com.microsoft.jenkins.containeragents.aci.dns.AciDnsServer;
 import com.microsoft.jenkins.containeragents.strategy.ContainerOnceRetentionStrategy;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import java.util.List;
 
 import static java.util.Collections.emptyList;
 
-public class AciCloudConfigTest {
-
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+@WithJenkins
+class AciCloudConfigTest {
 
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip(JenkinsRule jenkins) throws Exception {
         String cloudName = "aciTest";
         AciCloud expectedAciCloud = createConfiguredAciCloud(cloudName);
 
@@ -36,8 +34,6 @@ public class AciCloudConfigTest {
 
         AciCloud actualAciCloud = (AciCloud) jenkins.jenkins.getCloud(cloudName);
         jenkins.assertEqualDataBoundBeans(expectedAciCloud, actualAciCloud);
-
-
     }
 
     @NonNull

--- a/src/test/java/com/microsoft/jenkins/containeragents/AciCloudIT.java
+++ b/src/test/java/com/microsoft/jenkins/containeragents/AciCloudIT.java
@@ -1,6 +1,5 @@
 package com.microsoft.jenkins.containeragents;
 
-
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;

--- a/src/test/java/com/microsoft/jenkins/containeragents/AciRule.java
+++ b/src/test/java/com/microsoft/jenkins/containeragents/AciRule.java
@@ -36,12 +36,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 
-
 public class AciRule implements TestRule, MethodRule {
 
     private static final Logger LOGGER = Logger.getLogger(AciRule.class.getName());
 
-    public AciData data = new AciData();
+    public final AciData data = new AciData();
     protected Description testDescription;
 
     public AzureResourceManager azureClient = null;
@@ -59,7 +58,7 @@ public class AciRule implements TestRule, MethodRule {
     }
 
     public static class AciData implements Serializable {
-        public String label = AzureContainerUtils.generateName("AciTemplateTest",3);
+        public final String label = AzureContainerUtils.generateName("AciTemplateTest",3);
         public String storageAccountCredentialsId;
         public String fileShareName;
         public AzureStorageAccount.StorageAccountCredential storageAccountCredential;
@@ -67,8 +66,8 @@ public class AciRule implements TestRule, MethodRule {
         public final SimpleServicePrincipal servicePrincipal = new SimpleServicePrincipal();
 
         public final String cloudName = AzureContainerUtils.generateName("AzureContainerTest", 5);
-        public String location = loadProperty("ACI_AGENT_TEST_AZURE_LOCATION", "East US");
-        public String resourceGroup = AzureContainerUtils.generateName(loadProperty("ACI_AGENT_TEST_RESOURCE_GROUP", "AzureContainerTest"), 3);
+        public final String location = loadProperty("ACI_AGENT_TEST_AZURE_LOCATION", "East US");
+        public final String resourceGroup = AzureContainerUtils.generateName(loadProperty("ACI_AGENT_TEST_RESOURCE_GROUP", "AzureContainerTest"), 3);
 
         public String image;
         public String privateRegistryUrl;

--- a/src/test/java/com/microsoft/jenkins/containeragents/JCasCTest.java
+++ b/src/test/java/com/microsoft/jenkins/containeragents/JCasCTest.java
@@ -2,9 +2,10 @@ package com.microsoft.jenkins.containeragents;
 
 import com.microsoft.jenkins.containeragents.aci.AciCloud;
 import com.microsoft.jenkins.containeragents.aci.AciContainerTemplate;
-import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import io.jenkins.plugins.casc.misc.junit.jupiter.AbstractRoundTripTest;
 import jenkins.model.Jenkins;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import java.util.List;
 
@@ -15,9 +16,11 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class JCasCTest extends RoundTripAbstractTest {
+@WithJenkins
+class JCasCTest extends AbstractRoundTripTest {
+
     @Override
-    protected void assertConfiguredAsExpected(RestartableJenkinsRule j, String configContent) {
+    protected void assertConfiguredAsExpected(JenkinsRule j, String configContent) {
         AciCloud aciCloud = (AciCloud) Jenkins.get().getCloud("Aci");
         List<AciContainerTemplate> templates = aciCloud.getTemplates();
         assertThat(templates, hasSize(1));

--- a/src/test/java/com/microsoft/jenkins/containeragents/aci/AciContainerTemplateTest.java
+++ b/src/test/java/com/microsoft/jenkins/containeragents/aci/AciContainerTemplateTest.java
@@ -1,15 +1,14 @@
 package com.microsoft.jenkins.containeragents.aci;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-
-public class AciContainerTemplateTest {
+class AciContainerTemplateTest {
 
     @Test
-    public void ignoreWhitespaceInImageName() {
+    void ignoreWhitespaceInImageName() {
         AciContainerTemplate templateUnderTest = new AciContainerTemplate("name", "label", 100,
                 "osType", " image ", "command" , "rootFs", null, null,
                 null, null, null, "cpu", "memory");

--- a/src/test/java/com/microsoft/jenkins/containeragents/aci/dns/AciDnsConfigTest.java
+++ b/src/test/java/com/microsoft/jenkins/containeragents/aci/dns/AciDnsConfigTest.java
@@ -1,17 +1,16 @@
 package com.microsoft.jenkins.containeragents.aci.dns;
 
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
-public class AciDnsConfigTest {
+class AciDnsConfigTest {
 
     @Test
-    public void emptyDnServerNamesAreIgnored(){
+    void emptyDnServerNamesAreIgnored(){
         AciDnsConfig configUnderTest = new AciDnsConfig();
         configUnderTest.setDnsServers(Arrays.asList(new AciDnsServer("dnsServerName"), new AciDnsServer("")));
 

--- a/src/test/java/com/microsoft/jenkins/containeragents/builders/AciDeploymentTemplateBuilderTest.java
+++ b/src/test/java/com/microsoft/jenkins/containeragents/builders/AciDeploymentTemplateBuilderTest.java
@@ -1,6 +1,5 @@
 package com.microsoft.jenkins.containeragents.builders;
 
-
 import com.microsoft.jenkins.containeragents.aci.AciAgent;
 import com.microsoft.jenkins.containeragents.aci.AciCloud;
 import com.microsoft.jenkins.containeragents.aci.AciContainerTemplate;
@@ -10,8 +9,8 @@ import com.microsoft.jenkins.containeragents.aci.dns.AciDnsServer;
 import hudson.slaves.RetentionStrategy;
 import hudson.slaves.SlaveComputer;
 import io.jenkins.plugins.util.JenkinsFacade;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -23,13 +22,13 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AciDeploymentTemplateBuilderTest {
+class AciDeploymentTemplateBuilderTest {
 
-    AciAgent agentMock = mock(AciAgent.class);
-    AciDeploymentTemplateBuilder builderUnderTest;
+    private final AciAgent agentMock = mock(AciAgent.class);
+    private AciDeploymentTemplateBuilder builderUnderTest;
 
-    @Before
-    public void setup(){
+    @BeforeEach
+    void setup() {
         SlaveComputer slaveMock = mock(SlaveComputer.class);
         when(agentMock.getComputer()).thenReturn(slaveMock);
 
@@ -40,7 +39,7 @@ public class AciDeploymentTemplateBuilderTest {
     }
 
     @Test
-    public void templateWithVnet() throws IOException {
+    void templateWithVnet() throws IOException {
         AciCloud cloud = new AciCloud("testcloud", "credentialId", "resourceGroup", emptyList());
 
         AciContainerTemplate template = new AciContainerTemplate("containerName", "label", 100, "linux", "helloworld", "command", "rootFs", emptyList(), emptyList(), emptyList(), emptyList(), new RetentionStrategy.Always(), "cpu", "memory" );
@@ -55,7 +54,7 @@ public class AciDeploymentTemplateBuilderTest {
     }
 
     @Test
-    public void templateWithVnetAndOwnRg() throws IOException {
+    void templateWithVnetAndOwnRg() throws IOException {
         AciCloud cloud = new AciCloud("testcloud", "credentialId", "resourceGroup", emptyList());
 
         AciContainerTemplate template = new AciContainerTemplate("containerName", "label", 100, "linux", "helloworld", "command", "rootFs", emptyList(), emptyList(), emptyList(), emptyList(), new RetentionStrategy.Always(), "cpu", "memory" );
@@ -72,7 +71,7 @@ public class AciDeploymentTemplateBuilderTest {
     }
 
     @Test
-    public void templateWithVnetAndOwnButEmptyRg() throws IOException {
+    void templateWithVnetAndOwnButEmptyRg() throws IOException {
         AciCloud cloud = new AciCloud("testcloud", "credentialId", "resourceGroup", emptyList());
 
         AciContainerTemplate template = new AciContainerTemplate("containerName", "label", 100, "linux", "helloworld", "command", "rootFs", emptyList(), emptyList(), emptyList(), emptyList(), new RetentionStrategy.Always(), "cpu", "memory" );
@@ -89,7 +88,7 @@ public class AciDeploymentTemplateBuilderTest {
     }
 
     @Test
-    public void templateWithVnetAndDnsConfig() throws IOException {
+    void templateWithVnetAndDnsConfig() throws IOException {
         AciCloud cloud = new AciCloud("testcloud", "credentialId", "resourceGroup", emptyList());
 
         AciContainerTemplate template = new AciContainerTemplate("containerName", "label", 100, "linux", "helloworld", "command", "rootFs", emptyList(), emptyList(), emptyList(), emptyList(), new RetentionStrategy.Always(), "cpu", "memory" );
@@ -106,7 +105,7 @@ public class AciDeploymentTemplateBuilderTest {
     }
 
     @Test
-    public void templateWithVnetAndDnsConfigWithoutDnsServer() throws IOException {
+    void templateWithVnetAndDnsConfigWithoutDnsServer() throws IOException {
         AciCloud cloud = new AciCloud("testcloud", "credentialId", "resourceGroup", emptyList());
 
         AciContainerTemplate template = new AciContainerTemplate("containerName", "label", 100, "linux", "helloworld", "command", "rootFs", emptyList(), emptyList(), emptyList(), emptyList(), new RetentionStrategy.Always(), "cpu", "memory" );
@@ -121,7 +120,7 @@ public class AciDeploymentTemplateBuilderTest {
 
 
     @Test
-    public void templateWithVnetWithoutDnsConfig() throws IOException {
+    void templateWithVnetWithoutDnsConfig() throws IOException {
         AciCloud cloud = new AciCloud("testcloud", "credentialId", "resourceGroup", emptyList());
 
         AciContainerTemplate template = new AciContainerTemplate("containerName", "label", 100, "linux", "helloworld", "command", "rootFs", emptyList(), emptyList(), emptyList(), emptyList(), new RetentionStrategy.Always(), "cpu", "memory" );
@@ -133,7 +132,7 @@ public class AciDeploymentTemplateBuilderTest {
     }
 
     @Test
-    public void templateWithoutVnet() throws IOException {
+    void templateWithoutVnet() throws IOException {
         AciCloud cloud = new AciCloud("testcloud", "credentialId", "resourceGroup", emptyList());
 
         AciContainerTemplate template = new AciContainerTemplate("containerName", "label", 100, "linux", "helloworld", "command", "rootFs", emptyList(), emptyList(), emptyList(), emptyList(), new RetentionStrategy.Always(), "cpu", "memory" );

--- a/src/test/java/com/microsoft/jenkins/containeragents/strategy/ProvisionRetryStrategyTest.java
+++ b/src/test/java/com/microsoft/jenkins/containeragents/strategy/ProvisionRetryStrategyTest.java
@@ -1,53 +1,57 @@
 package com.microsoft.jenkins.containeragents.strategy;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ProvisionRetryStrategyTest {
+class ProvisionRetryStrategyTest {
 
-    ProvisionRetryStrategy strategy = new ProvisionRetryStrategy();
+    private final ProvisionRetryStrategy strategy = new ProvisionRetryStrategy();
 
     @Test
-    public void testSuccess() {
+    void testSuccess() {
         final String templateName = "TEMPLATE1";
         strategy.getRecords().put(templateName, new ProvisionRetryStrategy.Record());
-        Assert.assertTrue(strategy.getRecords().containsKey(templateName));
+        assertTrue(strategy.getRecords().containsKey(templateName));
         strategy.success(templateName);
-        Assert.assertFalse(strategy.getRecords().containsKey(templateName));
+        assertFalse(strategy.getRecords().containsKey(templateName));
     }
 
     @Test
-    public void testFailure() {
+    void testFailure() {
         final String templateName = "TEMPLATE2";
         strategy.failure(templateName);
         ProvisionRetryStrategy.Record record = strategy.getRecords().get(templateName);
-        Assert.assertNotNull(record);
+        assertNotNull(record);
         final int interval = record.getInterval();
-        Assert.assertThat(interval, greaterThan(0));
+        assertThat(interval, greaterThan(0));
         strategy.failure(templateName);
-        Assert.assertEquals(interval * 2, record.getInterval());
+        assertEquals(interval * 2, record.getInterval());
     }
 
     @Test
-    public void testIsEnabled() {
+    void testIsEnabled() {
         final String templateName = "TEMPLATE3";
-        Assert.assertTrue(strategy.isEnabled(templateName));
+        assertTrue(strategy.isEnabled(templateName));
         strategy.failure(templateName);
-        Assert.assertFalse(strategy.isEnabled(templateName));
+        assertFalse(strategy.isEnabled(templateName));
         strategy.success(templateName);
-        Assert.assertTrue(strategy.isEnabled(templateName));
+        assertTrue(strategy.isEnabled(templateName));
 
 
         strategy.failure(templateName);
-        Assert.assertFalse(strategy.isEnabled(templateName));
+        assertFalse(strategy.isEnabled(templateName));
         long interval = strategy.getNextRetryTime(templateName) - System.currentTimeMillis();
         try {
             Thread.sleep(interval + 500);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
-        Assert.assertTrue(strategy.isEnabled(templateName));
+        assertTrue(strategy.isEnabled(templateName));
     }
 }

--- a/src/test/java/com/microsoft/jenkins/containeragents/utils/DockerRegistryUtilsTest.java
+++ b/src/test/java/com/microsoft/jenkins/containeragents/utils/DockerRegistryUtilsTest.java
@@ -1,13 +1,14 @@
 package com.microsoft.jenkins.containeragents.utils;
 
 import com.microsoft.jenkins.containeragents.util.DockerRegistryUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DockerRegistryUtilsTest {
+class DockerRegistryUtilsTest {
+
     @Test
-    public void testFormatUrlToWithProtocol() {
+    void testFormatUrlToWithProtocol() {
         assertEquals("", DockerRegistryUtils.formatUrlToWithProtocol(""));
         assertEquals("https://example.io", DockerRegistryUtils.formatUrlToWithProtocol("example.io"));
         assertEquals("HTTPS://example.io", DockerRegistryUtils.formatUrlToWithProtocol("HTTPS://example.io"));
@@ -15,7 +16,7 @@ public class DockerRegistryUtilsTest {
     }
 
     @Test
-    public void testFormatUrlToWithoutProtocol() {
+    void testFormatUrlToWithoutProtocol() {
         assertEquals("", DockerRegistryUtils.formatUrlToWithoutProtocol(""));
         assertEquals("example.io", DockerRegistryUtils.formatUrlToWithoutProtocol("HTTPS://example.io"));
         assertEquals("example.io", DockerRegistryUtils.formatUrlToWithoutProtocol("HTTP://example.io"));


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

There are 3 exceptions where tests use rules that have not yet been migrated to JUnit5:

* `AciCloudIT` using `RealJenkinsRule`
* `AciCloudQuickIT` using `RealJenkinsRule`
* `AciRule` used by above tests

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue