### PR TITLE
Update Jenkins baseline to 2.555.3 and require Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,6 @@ buildPlugin(
   forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 25],
+    [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,22 @@
         <changelist>9999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.baseline>2.555</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     </properties>
 
     <dependencies>
+        <!-- an old transitive tika-core offers jakarta APIs at a shallower depth than the
+             newer ones from azure-sdk; declare them so the newer versions resolve -->
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jakarta-activation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jakarta-xml-bind-api</artifactId>
+        </dependency>
         <!-- libraries -->
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
@@ -121,7 +131,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>5054.v620b_5d2b_d5e6</version>
+                <version>6931.vea_a_b_c6fd017d</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/test/java/com/microsoft/jenkins/containeragents/AciCloudConfigTest.java
+++ b/src/test/java/com/microsoft/jenkins/containeragents/AciCloudConfigTest.java
@@ -28,7 +28,7 @@ class AciCloudConfigTest {
         jenkins.jenkins.clouds.add(expectedAciCloud);
         jenkins.jenkins.save();
         JenkinsRule.WebClient testClient = jenkins.createWebClient();
-        HtmlPage cloudPage = testClient.goTo("configureClouds/");
+        HtmlPage cloudPage = testClient.goTo(expectedAciCloud.getUrl() + "configure");
         HtmlForm configForm = cloudPage.getFormByName("config");
         jenkins.submit(configForm);
 


### PR DESCRIPTION
Update the Jenkins baseline from 2.479.3 to 2.555.3, one of the [currently recommended versions](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions).

## What's changed

- `jenkins.baseline` 2.479 -> 2.555, and the plugin BOM to `bom-2.555.x`.
- Jenkins 2.555.1 and newer require Java 21, so the JDK 17 build had to move: `linux/21, windows/17` -> `linux/25, windows/21`, per the [Java support policy](https://www.jenkins.io/doc/book/platform-information/support-policy-java/).
- Declared `jakarta-activation-api` and `jakarta-xml-bind-api`: the newer BOM raises `windows-azure-storage`, whose `azure-sdk` reaches the Jakarta APIs at a deeper level than the old `tika-core` that ships alongside it, so nearest-wins picked the older ones and `requireUpperBoundDeps` failed.
- `AciCloudConfigTest` fetched `configureClouds/`, which current core no longer serves (404). It now uses `Cloud.getUrl() + "configure"`, the per-cloud page core renders today.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk baseline update across the plugins I maintain. If anything here looks wrong, please comment on this PR.
